### PR TITLE
V9.0.0/net9rc1 support

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        framework: [net8.0,net6.0]
+        framework: [net9.0,net8.0]
     outputs:
       version: ${{ steps.minver-calculate.outputs.version }}
     steps:

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -1,12 +1,12 @@
 name: Swashbuckle.AspNetCore Ext. CI/CD Pipeline
 on:
   pull_request:
-    branches: [main]
     paths-ignore:
       - .codecov
       - .docfx
       - .github
       - .nuget
+      - '**.md'
   workflow_dispatch:
     inputs:
       configuration:

--- a/.nuget/Codebelt.Extensions.Swashbuckle.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Swashbuckle.AspNetCore/PackageReleaseNotes.txt
@@ -1,4 +1,11 @@
-﻿Version 8.4.0
+﻿Version 9.0.0
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+- REMOVED Support for TFM .NET 6 (LTS)
+ 
+Version 8.4.0
 Availability: .NET 8 and .NET 6
  
 # ALM

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'false'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Copyright>Copyright © Geekle 2024. All rights reserved.</Copyright>
     <Authors>gimlichael</Authors>
     <Company>Geekle</Company>
@@ -48,12 +48,8 @@
     <None Include="..\..\.nuget\$(MSBuildProjectName)\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsLinux)' == 'true'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsWindows)' == 'true'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
@@ -70,8 +66,8 @@
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
@@ -81,7 +77,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Codebelt.Extensions.Xunit.App" Version="8.4.1" />
+    <PackageReference Include="Codebelt.Extensions.Xunit.App" Version="9.0.0-preview.4" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,8 +14,8 @@
 
   <Target Name="ApplyFileVersion" AfterTargets="MinVer">
     <PropertyGroup>
-      <BUILD_BUILDNUMBER Condition="'$(BUILD_BUILDNUMBER)' == ''">00000</BUILD_BUILDNUMBER>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BUILD_BUILDNUMBER)</FileVersion>
+      <GITHUB_RUN_NUMBER Condition="'$(GITHUB_RUN_NUMBER)' == ''">0</GITHUB_RUN_NUMBER>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Codebelt.Extensions.Swashbuckle.AspNetCore/Codebelt.Extensions.Swashbuckle.AspNetCore.csproj
+++ b/src/Codebelt.Extensions.Swashbuckle.AspNetCore/Codebelt.Extensions.Swashbuckle.AspNetCore.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Codebelt.Extensions.Asp.Versioning" Version="8.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageReference Include="Codebelt.Extensions.Asp.Versioning" Version="9.0.0-preview.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests.csproj
+++ b/test/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="8.3.2" />
+    <PackageReference Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.424-net8.0.303"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.425-net8.0.401-9.0.100-rc.1.24452.12"
         }
     ]
 }


### PR DESCRIPTION
#### PR Classification
Update to support .NET 9.0 and remove .NET 6.0.

#### PR Summary
Updated the project to target .NET 9.0, removed .NET 6.0, and made related dependency and configuration changes.
- `pipelines.yml`: Updated CI pipeline to use .NET 9.0,
- `Directory.Build.props`: Targeted .NET 9.0 and updated dependencies,
- `Directory.Build.targets`: Changed to use `GITHUB_RUN_NUMBER` for file version,
- `Codebelt.Extensions.Swashbuckle.AspNetCore.csproj`: Updated dependencies,
- `testenvironments.json`: Updated Docker image to include .NET 9.0.
