### PR TITLE
V9.0.0/rtm

### DIFF
--- a/.docfx/includes/availability-default.md
+++ b/.docfx/includes/availability-default.md
@@ -1,1 +1,1 @@
-Availability: .NET 8, .NET 6 and .NET Standard 2.0
+Availability: .NET 9, .NET 8 and .NET Standard 2.0

--- a/.docfx/includes/availability-modern.md
+++ b/.docfx/includes/availability-modern.md
@@ -1,1 +1,1 @@
-Availability: .NET 8 and .NET 6
+Availability: .NET 9 and .NET 8

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Asp.Versioning" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Codebelt.Extensions.Asp.Versioning" Version="9.0.0" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.0" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:6.0.427-net8.0.403-9.0.100-rc.2.24474.11"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.404-9.0.100"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes updates to the availability documentation, package versions, and test environment configurations to align with the latest .NET releases.

### Documentation Updates:
* Updated availability information to include .NET 9 in `.docfx/includes/availability-default.md` and `.docfx/includes/availability-modern.md`. [[1]](diffhunk://#diff-e7c6e56f92f2e9152c615f69aeb95db756fc7be579eacb9672a51ce58056b39aL1-R1) [[2]](diffhunk://#diff-95558ec93b4ec78af969c1b9e8e996f17ebdfa5f4b3517b744884f00ecdb78e6L1-R1)

### Package Version Updates:
* Updated several package versions from release candidates to stable versions in `Directory.Packages.props`.

### Test Environment Configuration:
* Updated the Docker image for the Ubuntu test environment in `testenvironments.json` to use the latest .NET versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated availability information to include support for .NET 9 alongside .NET 8 and .NET Standard 2.0.
  
- **Bug Fixes**
	- Removed outdated support for .NET 6 in the availability sections.

- **Chores**
	- Updated package dependencies to stable versions, including `Codebelt.Extensions` and `Swashbuckle.AspNetCore`.
	- Simplified Docker image version in the testing environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->