### PR TITLE
V9.0.3/package maintenance

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,14 +1,14 @@
-﻿FROM nginx:1.27.3-alpine AS base
+﻿FROM --platform=$BUILDPLATFORM nginx:1.27.5-alpine AS base
 RUN rm -rf /usr/share/nginx/html/*
 
-FROM codebeltnet/docfx:2.77.0 AS build
+FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.3 AS build
 
 ADD [".", "docfx"]
 
 RUN cd docfx; \
     docfx build
 
-FROM base AS final
+FROM nginx:1.27.5-alpine AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=build /build/docfx/wwwroot /usr/share/nginx/html
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -23,95 +23,43 @@ permissions:
 
 jobs:
   build:
-    name: 🛠️ Build
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    name: call-build
     strategy:
       matrix:
         configuration: [Debug, Release]
-        framework: [net9.0,net8.0]
-    outputs:
-      version: ${{ steps.minver-calculate.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install MinVer
-        uses: codebeltnet/dotnet-tool-install-minver@v1
-
-      - id: minver-calculate
-        name: Calculate Version
-        uses: codebeltnet/minver-calculate@v2
-
-      - name: Download swashbuckle.snk file
-        uses: codebeltnet/gcp-download-file@v1
-        with:
-          serviceAccountKey: ${{ secrets.GCP_TOKEN }}
-          bucketName: ${{ secrets.GCP_BUCKETNAME }}
-          objectName: swashbuckle.snk
-
-      - name: Restore Dependencies
-        uses: codebeltnet/dotnet-restore@v2
-
-      - name: Build for ${{ matrix.framework }} (${{ matrix.configuration }})
-        uses: codebeltnet/dotnet-build@v2
-        with:
-          configuration: ${{ matrix.configuration }}
-          framework: ${{ matrix.framework }}
+    uses: codebeltnet/jobs-dotnet-build/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      strong-name-key-filename: swashbuckle.snk
+    secrets:
+      GCP_TOKEN: ${{ secrets.GCP_TOKEN }}
+      GCP_BUCKETNAME: ${{ secrets.GCP_BUCKETNAME }}
 
   pack:
-    name: 📦 Pack
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    name: call-pack
+    needs: [build]
     strategy:
       matrix:
         configuration: [Debug, Release]
-    needs: [build]
-    steps:
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Pack for ${{ matrix.configuration }}
-        uses: codebeltnet/dotnet-pack@v2
-        with:
-          configuration: ${{ matrix.configuration }}
-          uploadPackedArtifact: true
-          version: ${{ needs.build.outputs.version }}
+    uses: codebeltnet/jobs-dotnet-pack/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      upload-packed-artifact: true
+      version: ${{ needs.build.outputs.version }}
 
   test:
-    name: 🧪 Test
+    name: call-test
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022]
         configuration: [Debug, Release]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install .NET Tool - Report Generator
-        uses: codebeltnet/dotnet-tool-install-reportgenerator@v1
-
-      - name: Test with ${{ matrix.configuration }} build
-        uses: codebeltnet/dotnet-test@v3
-        with:
-          configuration: ${{ matrix.configuration }}
-          buildSwitches: -p:SkipSignAssembly=true
+    uses: codebeltnet/jobs-dotnet-test/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      runs-on: ${{ matrix.os }}
+      build-switches: -p:SkipSignAssembly=true
 
   sonarcloud:
     name: call-sonarcloud
@@ -141,8 +89,8 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     name: call-nuget
-    needs: [build,pack,test,sonarcloud,codecov,codeql]
-    uses: codebeltnet/jobs-nuget/.github/workflows/default.yml@v1
+    needs: [build, pack, test, sonarcloud, codecov, codeql]
+    uses: codebeltnet/jobs-nuget-push/.github/workflows/default.yml@v1
     with:
       version: ${{ needs.build.outputs.version }}
       environment: Production

--- a/.nuget/Codebelt.Extensions.Swashbuckle.AspNetCore/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Swashbuckle.AspNetCore/PackageReleaseNotes.txt
@@ -1,4 +1,16 @@
-﻿Version 9.0.1
+﻿Version 9.0.3
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.2
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies to latest and greatest with respect to TFMs
+ 
+Version 9.0.1
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Codebelt.Extensions.Swashbuckle.AspNetCore.
 
+## [9.0.3] - 2025-05-25
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.2] - 2025-04-16
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,17 +4,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Codebelt.Bootstrapper.Web" Version="4.0.0" />
-    <PackageVersion Include="Codebelt.Extensions.Asp.Versioning" Version="9.0.2" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.0" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Codebelt.Extensions.Asp.Versioning" Version="9.0.3" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.1" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc.Formatters.Text.Json" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Codebelt.Extensions.Swashbuckle.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.Swashbuckle.AspNetCore/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ namespace Codebelt.Extensions.Swashbuckle.AspNetCore
         /// <param name="services">The <see cref="IServiceCollection"/> to extend.</param>
         /// <param name="setup">The <see cref="RestfulSwaggerOptions"/> that may be configured.</param>
         /// <returns>A reference to <paramref name="services" /> so that additional calls can be chained.</returns>
+        /// <remarks>This method expect a call to <c>services.AddRestfulApiVersioning()</c> prior to this.</remarks>
         public static IServiceCollection AddRestfulSwagger(this IServiceCollection services, Action<RestfulSwaggerOptions> setup = null)
         {
             Validator.ThrowIfInvalidConfigurator(setup, out var options);

--- a/test/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests/ServiceCollectionExtensionsTest.cs
@@ -37,14 +37,13 @@ namespace Codebelt.Extensions.Swashbuckle.AspNetCore
                            o.Conventions.Controller<Assets.V2.FakeController>().HasApiVersion(new ApiVersion(2, 0));
                        });
                        services.AddRestfulSwagger();
-                       services.AddSwaggerGen();
                    }, app =>
                    {
                        app.UseRouting();
                        app.UseEndpoints(routes => { routes.MapControllers(); });
                        app.UseSwagger();
                        app.UseSwaggerUI();
-                   }, hostFixture: null))
+                   }))
             {
                 var client = filter.Host.GetTestClient();
                 var result = await client.GetStringAsync("/swagger/v1/swagger.json");
@@ -164,14 +163,13 @@ namespace Codebelt.Extensions.Swashbuckle.AspNetCore
                            o.XmlDocumentations.AddByType(typeof(ServiceCollectionExtensionsTest));
                            o.JsonSerializerOptionsFactory = provider => provider.GetRequiredService<IOptions<JsonFormatterOptions>>().Value.Settings;
                        });
-                       services.AddSwaggerGen();
                    }, app =>
                    {
                        app.UseRouting();
                        app.UseEndpoints(routes => { routes.MapControllers(); });
                        app.UseSwagger();
                        app.UseSwaggerUI();
-                   }, hostFixture: null))
+                   }))
             {
                 var client = filter.Host.GetTestClient();
                 var result = await client.GetStringAsync("/swagger/v1/swagger.json");

--- a/test/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests/SwaggerGenOptionsExtensionsTest.cs
+++ b/test/Codebelt.Extensions.Swashbuckle.AspNetCore.Tests/SwaggerGenOptionsExtensionsTest.cs
@@ -42,7 +42,7 @@ namespace Codebelt.Extensions.Swashbuckle.AspNetCore
                        app.UseEndpoints(routes => { routes.MapControllers(); });
                        app.UseSwagger();
                        app.UseSwaggerUI();
-                   }, hostFixture: null))
+                   }))
             {
                 var client = filter.Host.GetTestClient();
                 var result = await client.GetStringAsync("/swagger/v1/swagger.json");
@@ -113,7 +113,7 @@ namespace Codebelt.Extensions.Swashbuckle.AspNetCore
                        app.UseEndpoints(routes => { routes.MapControllers(); });
                        app.UseSwagger();
                        app.UseSwaggerUI();
-                   }, hostFixture: null))
+                   }))
             {
                 var client = filter.Host.GetTestClient();
                 var result = await client.GetStringAsync("/swagger/v1/swagger.json");
@@ -184,7 +184,7 @@ namespace Codebelt.Extensions.Swashbuckle.AspNetCore
                        app.UseEndpoints(routes => { routes.MapControllers(); });
                        app.UseSwagger();
                        app.UseSwaggerUI();
-                   }, hostFixture: null))
+                   }))
             {
                 var client = filter.Host.GetTestClient();
                 var result = await client.GetStringAsync("/swagger/v1/swagger.json");

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.408-9.0.203"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.409-9.0.300"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes updates across multiple areas, including dependency upgrades, workflow optimizations, and minor code and test adjustments. The most significant changes focus on upgrading dependencies, improving CI/CD workflows by reusing modular workflows, and refining code and test implementations.

### Dependency Upgrades:
* Updated various package versions in `Directory.Packages.props`, including `Codebelt.Extensions.Asp.Versioning` to `9.0.3`, `Swashbuckle.AspNetCore` to `8.1.2`, and others. These upgrades ensure compatibility with the latest features and bug fixes.
* Updated the Docker image in `testenvironments.json` to use `gimlichael/ubuntu-testrunner:net8.0.409-9.0.300`.

### CI/CD Workflow Improvements:
* Simplified the `.github/workflows/pipelines.yml` file by replacing inline job definitions with reusable workflows for `build`, `pack`, `test`, and `nuget` tasks. This reduces redundancy and improves maintainability. [[1]](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L26-R62) [[2]](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L145-R93)

### Documentation Updates:
* Updated `CHANGELOG.md` and `PackageReleaseNotes.txt` with details about new versions, including `9.0.3`, which focuses on dependency updates for supported target frameworks. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-75cec10f6743e83d1ce03900e31becac2dbb462ac37bdd9b93523a4f3693f584L1-R13)

### Code Enhancements:
* Added a `<remarks>` tag to the `AddRestfulSwagger` method in `ServiceCollectionExtensions.cs` to clarify the expected call order for proper configuration.

### Test Adjustments:
* Removed redundant `services.AddSwaggerGen()` calls in multiple test methods to streamline test setups in `ServiceCollectionExtensionsTest.cs` and `SwaggerGenOptionsExtensionsTest.cs`. [[1]](diffhunk://#diff-567e5fb5ab85e406c6f3a25738664c3f8587717855eabb1fb44a9fa6b4c5b3f3L40-R46) [[2]](diffhunk://#diff-567e5fb5ab85e406c6f3a25738664c3f8587717855eabb1fb44a9fa6b4c5b3f3L167-R172) [[3]](diffhunk://#diff-1eb2e66c30a4c942c151e96a6609e6fe81fa5ffaea77ab15982d711ab1d3046fL45-R45) [[4]](diffhunk://#diff-1eb2e66c30a4c942c151e96a6609e6fe81fa5ffaea77ab15982d711ab1d3046fL116-R116) [[5]](diffhunk://#diff-1eb2e66c30a4c942c151e96a6609e6fe81fa5ffaea77ab15982d711ab1d3046fL187-R187)